### PR TITLE
Should not use local property file when installing into whisk.system

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 #
 # To run this command
 # ./install.sh <apihost> <authkey> <pathtowskcli>
-# ./install.sh APIHOST="$EDGE_HOST" AUTH="$AUTH_KEY" WSK_CLI="$OPENWHISK_HOME/bin/wsk"
+# ./install.sh APIHOST="$EDGE_HOST" AUTH="$AUTH_KEY" WSK_CLI="$OPENWHISK_HOME/bin/go-cli/wsk"
 # API_HOST and AUTH_KEY are found in $HOME/.wskprops
 
 set -e
@@ -21,6 +21,8 @@ AUTH="$2"
 WSK_CLI="$3"
 
 PACKAGE_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+export WSK_CONFIG_FILE= # override local property file to avoid namespace clashes
 
 # pushnotifications actions
 


### PR DESCRIPTION
If a user changes their namespace and runs the install.sh file the push notification package install will fail.  Push should not be using the namespace from the local property file when installing into whisk.system.
