### PR TITLE
packages directory in openwhisk no longer exists

### DIFF
--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -5,6 +5,7 @@ ROOTDIR="$SCRIPTDIR/../../openwhisk"
 
 cd $ROOTDIR
 
+mkdir $ROOTDIR/tests/src/packages
 cp $ROOTDIR/../tests/src/* $ROOTDIR/tests/src/packages/
 
 tools/build/scanCode.py .


### PR DESCRIPTION
Need to create the packages directory before copying the tests
