### PR TITLE
Add test dependency on openwhisk

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,14 @@
+include 'tests', ':WhiskTest', ':common:scala', ':core:invoker', ':core:controller'
+
+rootProject.name = 'openwhisk-package-pushnotifications'
+def whiskhome = "$System.env.OPENWHISK_HOME"
+
+project(':WhiskTest').projectDir = new File(whiskhome, 'tests')
+project(':common:scala').projectDir = new File(whiskhome + '/common', 'scala')
+project(':core:invoker').projectDir = new File(whiskhome + '/core', 'invoker')
+project(':core:controller').projectDir = new File(whiskhome + '/core', 'controller')
+
+gradle.ext.scala = [
+        version: '2.11.8',
+        compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
+]

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,0 +1,68 @@
+def whiskhome = "$System.env.OPENWHISK_HOME"
+
+apply plugin: 'scala'
+apply plugin: 'eclipse'
+compileTestScala.options.encoding = 'UTF-8'
+
+repositories {
+    mavenCentral()
+    maven {
+        url 'https://oss.sonatype.org/content/repositories/snapshots/'
+    }
+}
+
+sourceSets {
+    test {
+        scala {
+            srcDirs = ['src/']
+        }
+    }
+}
+
+test {
+    systemProperty 'testthreads', System.getProperty('testthreads', '1')
+    testLogging {
+        events "passed", "skipped", "failed"
+        showStandardStreams = true
+        exceptionFormat = 'full'
+    }
+    outputs.upToDateWhen { false } // force tests to run everytime
+}
+
+dependencies {
+    testCompile "org.scala-lang:scala-library:${gradle.scala.version}"
+    testCompile 'org.apache.commons:commons-exec:1.1'
+    testCompile 'org.apache.commons:commons-lang3:3.3.2'
+    testCompile 'commons-logging:commons-logging:1.1.3'
+    testCompile 'org.codehaus.groovy:groovy:2.4.3'
+    testCompile 'org.codehaus.groovy:groovy-json:2.4.3'
+    testCompile 'org.codehaus.groovy:groovy-xml:2.4.3'
+    testCompile 'com.google.guava:guava:18.0'
+    testCompile 'org.hamcrest:hamcrest-core:1.3'
+    testCompile 'org.apache.httpcomponents:httpmime:4.3.6'
+    testCompile 'junit:junit:4.11'
+    testCompile 'com.jayway.restassured:rest-assured:2.4.1'
+    testCompile 'org.scalatest:scalatest_2.11:2.2.4'
+    testCompile 'org.seleniumhq.selenium:selenium-java:2.45.0'
+    testCompile 'io.spray:spray-testkit_2.11:1.3.3'
+    testCompile 'io.spray:spray-json_2.11:1.3.2'
+    testCompile 'com.google.code.tempus-fugit:tempus-fugit:1.2-SNAPSHOT'
+    testCompile 'com.google.code.gson:gson:2.3.1'
+    testCompile project(':WhiskTest').sourceSets.test.output
+}
+
+tasks.withType(ScalaCompile) {
+    scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
+}
+
+def keystorePath = new File(buildDir, 'classes/test/keystore')
+task deleteKeystore(type: Delete) {
+    delete keystorePath
+}
+task createKeystore(dependsOn: deleteKeystore) << {
+    Properties props = new Properties()
+    props.load(new FileInputStream(file(whiskhome+'/whisk.properties')))
+    def cmd = ['keytool', '-import', '-alias', 'Whisk', '-noprompt', '-trustcacerts', '-file', file(props['whisk.ssl.cert']), '-keystore', keystorePath, '-storepass', 'openwhisk']
+    cmd.execute().waitForProcessOutput(System.out, System.err)
+}
+compileTestScala.finalizedBy createKeystore

--- a/tests/src/packages/PushNotificationsTests.scala
+++ b/tests/src/packages/PushNotificationsTests.scala
@@ -15,16 +15,11 @@
  */
 package packages
 
+import common.{TestHelpers, Wsk, WskProps, WskTestHelpers, _}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-
-import common.TestHelpers
-import common.Wsk
-import common.WskProps
-import common.WskTestHelpers
 import spray.json.DefaultJsonProtocol.StringJsonFormat
 import spray.json.pimpAny
-import common._
 
 @RunWith(classOf[JUnitRunner])
 class PushNotificationsTests

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -1,16 +1,14 @@
 # Build script for Travis-CI.
 
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
-ROOTDIR="$SCRIPTDIR/../../openwhisk"
+ROOTDIR="$SCRIPTDIR/../.."
+WHISKDIR="$ROOTDIR/openwhisk"
 
-cd $ROOTDIR
-
-mkdir $ROOTDIR/tests/src/packages
-cp $ROOTDIR/../tests/src/* $ROOTDIR/tests/src/packages/
+cd $WHISKDIR
 
 tools/build/scanCode.py .
 
-cd $ROOTDIR/ansible
+cd $WHISKDIR/ansible
 
 ANSIBLE_CMD="ansible-playbook -i environments/local"
 
@@ -19,34 +17,34 @@ $ANSIBLE_CMD prereq.yml
 $ANSIBLE_CMD couchdb.yml
 $ANSIBLE_CMD initdb.yml
 
-cd $ROOTDIR
+cd $WHISKDIR
 
 ./gradlew distDocker
 
-cd $ROOTDIR/ansible
+cd $WHISKDIR/ansible
 
 $ANSIBLE_CMD wipe.yml
 $ANSIBLE_CMD openwhisk.yml
 $ANSIBLE_CMD postdeploy.yml
 
-cd $ROOTDIR
+cd $WHISKDIR
 
-VCAP_SERVICES_FILE="$(readlink -f $ROOTDIR/../tests/credentials.json)"
+VCAP_SERVICES_FILE="$(readlink -f $WHISKDIR/../tests/credentials.json)"
 
 #update whisk.properties to add tests/credentials.json file to vcap.services.file, which is needed in tests
-WHISKPROPS_FILE="$ROOTDIR/whisk.properties"
+WHISKPROPS_FILE="$WHISKDIR/whisk.properties"
 sed -i 's:^[ \t]*vcap.services.file[ \t]*=\([ \t]*.*\)$:vcap.services.file='$VCAP_SERVICES_FILE':'  $WHISKPROPS_FILE
 cat whisk.properties
 
-WSK_CLI=$ROOTDIR/bin/wsk
-AUTH_KEY=$(cat $ROOTDIR/ansible/files/auth.whisk.system)
+WSK_CLI=$WHISKDIR/bin/wsk
+AUTH_KEY=$(cat $WHISKDIR/ansible/files/auth.whisk.system)
 EDGE_HOST=$(grep '^edge.host=' $WHISKPROPS_FILE | cut -d'=' -f2)
 WSK_NAMESPACE=/whisk.system
 
 # Install the package
-source $ROOTDIR/../packages/installCatalog.sh $AUTH_KEY $EDGE_HOST $WSK_NAMESPACE $WSK_CLI
+source $ROOTDIR/packages/installCatalog.sh $AUTH_KEY $EDGE_HOST $WSK_NAMESPACE $WSK_CLI
 
-#Test only the test cases classes in tests/src (Openwhisk dependencies are needed)
-X="./gradlew :tests:test "
-for f in $(ls $ROOTDIR/../tests/src | sed -e 's/\..*$//'); do X="$X --tests \"packages.$f\""; done
-eval $X
+# Test
+cd $ROOTDIR
+./gradlew :tests:test
+


### PR DESCRIPTION
Adding a test dependency on openwhisk so the push notification tests can be run from within the push project.
