### PR TITLE
Switch to Scala 2.12.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install: true
 
 before_install:
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then openssl aes-256-cbc -K $encrypted_ff5bbb6225c5_key -iv $encrypted_ff5bbb6225c5_iv -in tests/credentials.json.enc -out tests/credentials.json -d; fi'
-  - git clone https://github.com/openwhisk/openwhisk.git
+  - git clone --depth=1 --single-branch -b scala-2-12 https://github.com/chetanmeh/incubator-openwhisk.git openwhisk
   - cd openwhisk
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./tools/travis/setup.sh; fi'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install: true
 
 before_install:
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then openssl aes-256-cbc -K $encrypted_ff5bbb6225c5_key -iv $encrypted_ff5bbb6225c5_iv -in tests/credentials.json.enc -out tests/credentials.json -d; fi'
-  - git clone --depth=1 --single-branch -b scala-2-12 https://github.com/chetanmeh/incubator-openwhisk.git openwhisk
+  - git clone https://github.com/openwhisk/openwhisk.git
   - cd openwhisk
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./tools/travis/setup.sh; fi'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: scala
 
 scala:
-  - 2.11.6
+  - 2.12.7
 
 services:
   - docker

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,6 @@ gradle.ext.openwhisk = [
 ]
 
 gradle.ext.scala = [
-    version: '2.11.8',
+    version: '2.12.7',
     compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
 ]


### PR DESCRIPTION
Switches Scala version to 2.12.7 as part of apache/incubator-openwhisk#3952

To validate that build passes fine this PR build against the [scala-2-12][1] branch. Following sequence of steps would happen

1. apache/incubator-openwhisk#4062 is merged
2. Change the git url in install scripts
3. Merge this PR

[1]: https://github.com/chetanmeh/incubator-openwhisk/tree/scala-2-12